### PR TITLE
create .gitattributes to handle EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# End of line characters are a problem when the team is developing on Windows (CRLF), Unix (LF), and Mac (LF) 
+# This small file will fix that.  Line endings in the repository will be set to LF while local line endings will be left "alone".  
+# This enables windows users to develop using CRLF but then push using LF.
+
+* text=auto


### PR DESCRIPTION
If team members are developing in *nix, windows, and mac, line endings can be a problem. 

Two possible fixes are: 
1.  edit every user's users git-config https://stackoverflow.com/questions/2825428/why-should-i-use-core-autocrlf-true-in-git, or 
2.  Handle in the repository by setting everything in the repo to LF, while allowing the Windows users to use CRLF when developing locally, 

further reading:
https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/

